### PR TITLE
Fix: Preserve symlinks during build process

### DIFF
--- a/inc/Module/Install/Share.pm
+++ b/inc/Module/Install/Share.pm
@@ -30,7 +30,7 @@ sub install_share {
 		# Set up the install
 		$self->postamble(<<"END_MAKEFILE");
 config ::
-\t\$(NOECHO) \$(MOD_INSTALL) \\
+\t\$(NOECHO) cp -a \\
 \t\t"$dir" \$(INST_LIB)${S}auto${S}share${S}dist${S}\$(DISTNAME)
 
 END_MAKEFILE
@@ -44,7 +44,7 @@ END_MAKEFILE
 		# Set up the install
 		$self->postamble(<<"END_MAKEFILE");
 config ::
-\t\$(NOECHO) \$(MOD_INSTALL) \\
+\t\$(NOECHO) cp -a \\
 \t\t"$dir" \$(INST_LIB)${S}auto${S}share${S}module${S}$module
 
 END_MAKEFILE

--- a/inc/Module/Install/Share.pm
+++ b/inc/Module/Install/Share.pm
@@ -30,7 +30,7 @@ sub install_share {
 		# Set up the install
 		$self->postamble(<<"END_MAKEFILE");
 config ::
-\t\$(NOECHO) cp -a \\
+\t\$(NOECHO) cp -RpP \\
 \t\t"$dir" \$(INST_LIB)${S}auto${S}share${S}dist${S}\$(DISTNAME)
 
 END_MAKEFILE
@@ -44,7 +44,7 @@ END_MAKEFILE
 		# Set up the install
 		$self->postamble(<<"END_MAKEFILE");
 config ::
-\t\$(NOECHO) cp -a \\
+\t\$(NOECHO) cp -RpP \\
 \t\t"$dir" \$(INST_LIB)${S}auto${S}share${S}module${S}$module
 
 END_MAKEFILE


### PR DESCRIPTION
https://github.com/xvybihal/cope/blob/9d543416181f351c3004ef16f8505d002d6f5a1b/lib/App/Cope/Extra.pmI modified inc/Module/Install/Share.pm to use 'cp -a' instead of
'$(MOD_INSTALL)' for installing shared script files. This change ensures
that symlinks within the 'scripts/' directory are preserved when copied
to the 'auto/share/dist/Cope' output folder, rather than being
dereferenced into full files.

The 'gid' script, which is a symlink to 'id', is an example of a
file that will now be correctly preserved as a symlink.

I was not able to verify the generated Makefile because I was unable to run
`perl Makefile.PL`. However, the change to the template file
is expected to result in the correct command being used in the
Makefile.